### PR TITLE
syntax: expand link pattern to punctuation, link & title

### DIFF
--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -105,8 +105,34 @@
         "link": {
             "patterns": [
                 {
-                    "name": "variable.org",
-                    "match": "\\[\\[[^\\[\\]]+\\](?:\\[[^\\[\\]]+\\])?\\]"
+                    "name": "meta.link.inline.org",
+                    "match": "(\\[\\[)([^\\[\\]]+)(\\])(?:(\\[)([^\\[\\]]+)(\\]))?(\\])",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.string.begin.org"
+                        },
+                        "2": {
+                            "name": "markup.underline.link.org"
+                        },
+                        "3": {
+                            "name": "punctuation.definition.string.end.org"
+                        },
+                        "4": {
+                            "name": "punctuation.definition.string.begin.org"
+                        },
+                        "5": {
+                            "name": "string.other.link.title.org"
+                        },
+                        "6": {
+                            "name": "punctuation.definition.string.end.org"
+                        },
+                        "7": {
+                            "name": "punctuation.definition.string.end.org"
+                        },
+                        "8": {
+                            "name": "punctuation.definition.string.end.org"
+                        }
+                    }
                 }
             ]
         },


### PR DESCRIPTION
Adds better syntax support for links so that it is in parity with markdown, will leverage markdown link + title from other color themes.

Before:
![image](https://user-images.githubusercontent.com/1024544/31157480-2aff5e34-a870-11e7-890d-c8340143a36d.png)

After:
![image](https://user-images.githubusercontent.com/1024544/31157491-4420a8e6-a870-11e7-9b15-843f64bc3f61.png)

(captures beginning and ending punctuation, the link and the title as the same scopes as Markdown)