### PR TITLE
Added clock functions and parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,18 @@
                 "title": "Org: Timestamp"
             },
             {
+                "command": "org.clockin",
+                "title": "Org: Clock In"
+            },
+            {
+                "command": "org.clockout",
+                "title": "Org: Clock Out"
+            },
+            {
+                "command": "org.updateclock",
+                "title": "Org: Update Clock Total"
+            },
+            {
                 "command": "org.incrementContext",
                 "title": "Org: Increment Context"
             },
@@ -119,6 +131,21 @@
                         "DONE"
                     ],
                     "description": "Specifies the types of TODO statuses available (for switching)."
+                },
+                "org.addLeftZero": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Add left zero to single-digit dates and months."
+                },
+                "org.clockInOutSeparator": {
+                    "type": "string",
+                    "default": "--",
+                    "description": "Clock in and clock out separator"
+                },
+                "org.clockTotalSeparator": {
+                    "type": "string",
+                    "default": " =>  ",
+                    "description": "Clock total separator"
                 }
             }
         },
@@ -162,6 +189,21 @@
             {
                 "command": "org.timestamp",
                 "key": "ctrl+alt+o t",
+                "when": "editorLangId == 'org'"
+            },
+            {
+                "command": "org.clockin",
+                "key": "ctrl+alt+o ctrl+i",
+                "when": "editorLangId == 'org'"
+            },
+            {
+                "command": "org.clockout",
+                "key": "ctrl+alt+o ctrl+o",
+                "when": "editorLangId == 'org'"
+            },
+            {
+                "command": "org.updateclock",
+                "key": "ctrl+alt+o ctrl+u",
                 "when": "editorLangId == 'org'"
             },
             {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,9 @@ export function activate(context: vscode.ExtensionContext) {
     let demoteSubtreeCmd = vscode.commands.registerTextEditorCommand('org.demoteSubtree', SubtreeFunctions.demoteSubtree);
 
     let insertTimestampCmd = vscode.commands.registerTextEditorCommand('org.timestamp', TimestampFunctions.insertTimestamp);
+    let clockInCmd = vscode.commands.registerTextEditorCommand('org.clockin', TimestampFunctions.clockIn);
+    let clockOutCmd = vscode.commands.registerTextEditorCommand('org.clockout', TimestampFunctions.clockOut);
+    let updateClockCmd = vscode.commands.registerTextEditorCommand('org.updateclock', TimestampFunctions.updateClock);
 
     let incrementContextCmd = vscode.commands.registerTextEditorCommand('org.incrementContext', incrementContext);
 

--- a/src/timestamp-functions.ts
+++ b/src/timestamp-functions.ts
@@ -6,8 +6,67 @@ export function insertTimestamp(textEditor: vscode.TextEditor, edit: vscode.Text
     const document = Utils.getActiveTextEditorEdit();
     const cursorPos = Utils.getCursorPosition();
     
-    const dateObject = Datetime.currentDatetime();
+    const dateObject = Datetime.currentDate();
     const dateString = Datetime.buildDateString(dateObject);
 
     edit.insert(cursorPos, dateString);
+}
+
+export function clockIn(textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit) {
+    const document = Utils.getActiveTextEditorEdit();
+    const cursorPos = Utils.getCursorPosition();
+    const line = Utils.getLine(document, cursorPos);
+
+    if (line.indexOf('CLOCK:') === -1) {
+        edit.insert(cursorPos, 'CLOCK: ');
+    }
+    
+    insertDateTime(edit, cursorPos);
+}
+
+export function clockOut(textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit) {
+    const document = Utils.getActiveTextEditorEdit();
+    const cursorPos = Utils.getCursorPosition();
+    const line = Utils.getLine(document, cursorPos);
+
+    const separator = Utils.getClockInOutSeparator();
+    const separatorIndex = line.indexOf(separator);
+    if (separatorIndex !== -1) {
+        const initPos = new vscode.Position(cursorPos.line, separatorIndex);
+        const endPos = new vscode.Position(cursorPos.line, line.length);
+        const range = new vscode.Range(initPos, endPos);
+        edit.replace(range, '');
+    }
+    edit.insert(cursorPos, separator)
+    insertDateTime(edit, cursorPos);
+}
+
+export function updateClock(textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit) {
+    const document = Utils.getActiveTextEditorEdit();
+    const cursorPos = Utils.getCursorPosition();
+    const line = Utils.getLine(document, cursorPos);
+    
+    const clockTotal = Datetime.getClockTotal(line);
+    if (!clockTotal) {
+        vscode.window.showErrorMessage('You need two timestamps to update the clock total.');
+        return;
+    }
+    
+    const separator = Utils.getClockTotalSeparator();
+    const separatorIndex = line.indexOf(separator);
+    if (separatorIndex !== -1) {
+        const initPos = new vscode.Position(cursorPos.line, separatorIndex);
+        const endPos = new vscode.Position(cursorPos.line, line.length);
+        const range = new vscode.Range(initPos, endPos);
+        edit.replace(range, '');
+    }
+    edit.insert(cursorPos, separator)
+    edit.insert(cursorPos, clockTotal);
+}
+
+function insertDateTime(edit: vscode.TextEditorEdit, cursorPos: vscode.Position) {
+    const dateTimeObject = Datetime.currentDateTime();
+    const dateTimeString = Datetime.buildDateTimeString(dateTimeObject);
+
+    edit.insert(cursorPos, dateTimeString);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -196,6 +196,24 @@ export function getKeywords() {
     return todoKeywords;
 }
 
+export function getLeftZero() {
+    const settings = vscode.workspace.getConfiguration("org");
+    let addLeftZero = settings.get<boolean>("addLeftZero");
+    return addLeftZero;
+}
+
+export function getClockInOutSeparator() {
+    const settings = vscode.workspace.getConfiguration("org");
+    let clockInOutSeparator = settings.get<string>("clockInOutSeparator");
+    return clockInOutSeparator;
+}
+
+export function getClockTotalSeparator() {
+    const settings = vscode.workspace.getConfiguration("org");
+    let clockTotalSeparator = settings.get<string>("clockTotalSeparator");
+    return clockTotalSeparator;
+}
+
 export function getUniq(arr: string[]): string[] {
     // Must also preserve order
     let map = {};


### PR DESCRIPTION
New configurations:
- 'org.addLeftZero' - allow left zero padding on months, dates, hours and minutes (boolean, default false)
- 'org.clockInOutSeparator' - set the separator between clock in and clock out blocks (string, default "--")
- 'org.clockTotalSeparator' - set the separator between clocks and the clock total (string, default " =>  ")

New commands:
- 'org.clockin' - Adds the "CLOCK:" tag (if it doesn't already exists) and a [{year}-{month}-{day} {weekday} {hours}:{minutes}] timestamp
- 'org.clockout' - Clears previous clock out block (if exists), adds clockInOutSeparator and a [{year}-{month}-{day} {weekday} {hours}:{minutes}] timestamp
- 'org.updateclock' - Clears previous clock total block (if exists), add clockTotalSeparator and the difference between clockin and clockout in the {hours}:{minutes} format.
  Raises error if there's less than two timestamp blocks

Other additions/changes:
<simple-datetime.ts>
- interface 'ISimpleDateTime' - For the clock functions, extends ISimpleDate with hours and minutes
- function 'buildDateString' - Add verification for org.addLeftZero
- function 'padVal' - Renamed to padDate
- function 'buildDateTimeString' - Like buildDateString, but adds time
- function 'padTime' - Like padDate, but for times
- function 'dateToSimpleDateTime' - Like dateToSimpleDate, but returns a ISimpleDateTime
- function 'currentDatetime' - Renamed to 'currentDate'
- function 'currentDateTime' - Like currentDate, but returns an ISimpleDateTime
- function 'getClockTotal' - Returns the full string (separator + {hours}:{minutes}) for the clock total