### PR TITLE
syntax: make comments more specific and add keywords

### DIFF
--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -75,6 +75,9 @@
                 },
                 {
                     "include": "#comment"
+                },
+                {
+                    "include": "#keywords"
                 }
             ]
         },
@@ -185,8 +188,30 @@
         "comment": {
             "patterns": [
                 {
-                    "name": "comment.line.org",
-                    "match": "^#.+"
+                    "match": "(^|\\s)(#)\\s(.*)$",
+                    "captures": {
+                        "2": {
+                            "name": "punctuation.definition.comment"
+                        },
+                        "3": {
+                            "name": "comment.line"
+                        }
+                    }
+                }
+            ]
+        },
+        "keywords": {
+            "patterns": [
+                {
+                    "match": "^(#\\+.*:)\\s(.*)$",
+                    "captures": {
+                        "1": {
+                            "name": "support.type.property-name.org"
+                        },
+                        "2": {
+                            "name": "meta.structure.dictionary.value.org"
+                        }
+                    }
                 }
             ]
         }


### PR DESCRIPTION
Matches only comments for comments and sets keywords to be matched on  `support.type.property-name.org` for the key and `meta.structure.dictionary.value.org` for the value. This should match syntax highlighting for general key value pairs.

![image](https://user-images.githubusercontent.com/1024544/31186820-a27e8bdc-a8e4-11e7-9c5a-185e10d521ec.png)
