### PR TITLE
Fix for issue #94

### DIFF
--- a/src/cursor-context.ts
+++ b/src/cursor-context.ts
@@ -38,7 +38,7 @@ export default function getCursorContext(textEditor: TextEditor, edit: TextEdito
     // Match for TODO (or absence)
     const todoKeywords = Util.getKeywords().join("|");
     // const todoWords = "TODO|DONE";
-    const todoHeaderRegexp = new RegExp(`^(\\*+\\s+)(${todoKeywords})(?:\\b|\\[|$)`);
+    const todoHeaderRegexp = new RegExp(`^(\\s*\\*+\\s+)(${todoKeywords})(?:\\b|\\[|$)`);
     match = todoHeaderRegexp.exec(curLine);
     if (match) {
         // We've found our match


### PR DESCRIPTION
This is a quick fix for #94 

This is my first contribution to someone else's repo so please tell me if I have made any mistakes or faux pas. I am by no means a regex expert so please give it a quick check. I have tested this and it seems to work fine and no reports of it breaking anything.

The same thing could also be achieved by removing the ^ anchor, but if my understanding is correct, that would then allow the matching of multiple TODOs on one line, which sounds undesirable and would likely create some strange behaviour.

